### PR TITLE
save and reuse Random (sonar java:S2119)

### DIFF
--- a/core/src/main/java/org/libreoffice/lots/mailmerge/print/OOoBasedMailMerge.java
+++ b/core/src/main/java/org/libreoffice/lots/mailmerge/print/OOoBasedMailMerge.java
@@ -144,6 +144,8 @@ public class OOoBasedMailMerge implements AutoCloseable
   private String dbName;
   private short type;
 
+  private Random random = new Random();
+
   /**
    * Create a mail merge based on LibreOffice.
    *
@@ -772,7 +774,7 @@ public class OOoBasedMailMerge implements AutoCloseable
     UnoDictionary<Object> names = UnoDictionary.create(UNO.dbContext, Object.class);
     do
     {
-      dbName = TEMP_WOLLMUX_MAILMERGE_PREFIX + new Random().nextInt(100000);
+      dbName = TEMP_WOLLMUX_MAILMERGE_PREFIX + this.random.nextInt(100000);
     } while (names.containsKey(dbName));
 
     try

--- a/core/src/main/java/org/libreoffice/lots/slv/ContentBasedDirectiveModel.java
+++ b/core/src/main/java/org/libreoffice/lots/slv/ContentBasedDirectiveModel.java
@@ -87,6 +87,8 @@ public class ContentBasedDirectiveModel
 
   private static final Map<HashableComponent, ContentBasedDirectiveModel> models = new HashMap<>();
 
+  private Random random = new Random();
+
   /**
    * Creates a model for the given controller if it doesn't exist. Otherwise
    * returns the associated model.
@@ -436,7 +438,7 @@ public class ContentBasedDirectiveModel
     XStyle style = null;
     while (style == null)
     {
-      name = "NO" + new Random().nextInt(1000) + "_" + parentName;
+      name = "NO" + this.random.nextInt(1000) + "_" + parentName;
       try
       {
         style = StyleService.createParagraphStyle(doc, name, parentName);


### PR DESCRIPTION
"Creating a new Random object each time a random value is needed is inefficient and may produce numbers that are not random, depending on the JDK. For better efficiency and randomness, create a single Random, store it, and reuse it."

also test CI for pull-requests ;-)