### PR TITLE
Translated Comments from German to English

### DIFF
--- a/core/src/main/java/org/libreoffice/lots/db/SchemaDatasource.java
+++ b/core/src/main/java/org/libreoffice/lots/db/SchemaDatasource.java
@@ -40,11 +40,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Datenquelle, die die Daten einer existierenden Datenquelle mit geänderten Spalten
- * zur Verfügung stellt.
+ * Data source that provides the data of an existing data source with modified columns.
  *
- * @author Matthias Benkmann (D-III-ITD 5.1)
+ * @autor Matthias Benkmann (D-III-ITD 5.1)
  */
+
 public class SchemaDatasource extends Datasource
 {
 
@@ -65,18 +65,16 @@ public class SchemaDatasource extends Datasource
   private Map<String, String> mapNewToOld;
 
   /**
-   * Erzeugt eine neue SchemaDatasource.
+   * Creates a new SchemaDatasource.
    *
    * @param nameToDatasource
-   *          enthält alle bis zum Zeitpunkt der Definition dieser SchemaDatasource
-   *          bereits vollständig instanziierten Datenquellen.
+   *          contains all data sources that have already been fully instantiated at the time of the definition of this SchemaDatasource.
    * @param sourceDesc
-   *          der "DataSource"-Knoten, der die Beschreibung dieser SchemaDatasource
-   *          enthält.
+   *          the "DataSource" node that contains the description of this SchemaDatasource.
    * @param context
-   *          der Kontext relativ zu dem URLs aufgelöst werden sollen (zur Zeit nicht
-   *          verwendet).
+   *          the context relative to which URLs should be resolved (currently not used).
    */
+  
   public SchemaDatasource(Map<String, Datasource> nameToDatasource,
       ConfigThingy sourceDesc, URL context)
   {
@@ -96,12 +94,11 @@ public class SchemaDatasource extends Datasource
     List<String> columnsToAdd = addColumns(sourceDesc.query("ADD"), columnsToDrop);
     renameColumn(sourceDesc.query("RENAME"), columnsToDrop, columnsToAdd);
 
-    /**
-     * Für alle hinzugefügten Spalten, die weder in der Originaldatenbank existieren
-     * noch durch einen RENAME auf eine Spalte der Originaldatenbank abgebildet
-     * werden, füge ein Pseudomapping auf EMPTY_COLUMN hinzu, damit
-     * RenameDataset.get() weiss, dass es für die Spalte null liefern soll.
+     /**
+     * For all added columns that neither exist in the original database nor are mapped to a column of the original database by a RENAME,
+     * add a pseudo-mapping to EMPTY_COLUMN so that RenameDataset.get() knows that it should return null for the column.
      */
+    
     for (String spalte : columnsToAdd)
     {
       if (!schema.contains(spalte) && !mapNewToOld.containsKey(spalte))
@@ -210,12 +207,12 @@ public class SchemaDatasource extends Datasource
       QueryPart p = iter.next();
       String spalte = p.getColumnName();
 
-      if (!schema.contains(spalte)) // dieser Test ist nicht redundant wegen DROPs
+      if (!schema.contains(spalte)) // this test is not redundant because of DROPs
         return new QueryResultsList(new Vector<RenameDataset>(0));
 
       String alteSpalte = mapNewToOld.get(spalte);
 
-      if (alteSpalte == /* nicht equals()!!!! */EMPTY_COLUMN)
+      if (alteSpalte == /* not equals()!!!! */EMPTY_COLUMN)
         return new QueryResultsList(new Vector<RenameDataset>(0));
 
       if (alteSpalte != null)
@@ -254,14 +251,14 @@ public class SchemaDatasource extends Datasource
     @Override
     public String get(String columnName) throws ColumnNotFoundException
     {
-      // dieser Test ist nicht redundant wegen DROPs
+      // this test is not redundant because of DROPs
       if (!schema.contains(columnName))
         throw new ColumnNotFoundException(L.m("Column \"{0}\" does not exist!",
           columnName));
 
       String alteSpalte = mapNewToOld.get(columnName);
 
-      if (alteSpalte == /* nicht equals()!!!! */EMPTY_COLUMN) {
+      if (alteSpalte == /* not equals()!!!! */EMPTY_COLUMN) {
         return null;
       }
 

--- a/core/src/main/java/org/libreoffice/lots/db/Search.java
+++ b/core/src/main/java/org/libreoffice/lots/db/Search.java
@@ -32,7 +32,7 @@ import java.util.stream.Stream;
 import org.libreoffice.lots.config.ConfigThingy;
 
 /**
- * Diese Klasse stellt Methoden zur Verfügung um in Datenquellen Suchen durchzuführen.
+ * This class provides methods to perform searches in data sources.
  */
 public class Search
 {
@@ -43,19 +43,19 @@ public class Search
   }
 
   /**
-   * Führt die übergebene Suchanfrage gemäß der übergebenen Suchstrategie aus und liefert die
-   * Ergebnisse in einem {@link QueryResults}-Objekt zurück. Falls einer der übergebenen Parameter
-   * <code>null</code> ist oder falls der queryString leer ist, wird <code>null</code>
-   * zurückgeliefert.
+   * Executes the given search query according to the given search strategy and returns the
+   * results in a {@link QueryResults} object. If any of the given parameters
+   * is <code>null</code> or if the queryString is empty, <code>null</code>
+   * is returned.
    *
    * @param queryString
-   *          die Suchanfrage
+   *          the search query
    * @param searchStrategy
-   *          die zu verwendende Suchstrategie
+   *          the search strategy to use
    * @param datasources
    *          Data source to use.
    * @throws IllegalArgumentException
-   *           falls eine Datenquelle, in der gesucht werden soll, nicht existiert
+   *           if a data source to be searched does not exist
    * @return Results as an Iterable of Dataset as {@link QueryResults}
    */
   public static QueryResults search(String queryString, SearchStrategy searchStrategy,
@@ -86,9 +86,9 @@ public class Search
   }
 
   /**
-   * Führt die Ergenismengen zusammen. Dabei werden mehrfache Ergebnisse ausgefiltert.
+   * Merges the result sets. Duplicate results are filtered out.
    *
-   * @return bereinigte Ergebnisliste.
+   * @return cleaned result list.
    */
   private static QueryResults mergeListOfQueryResultsList(List<QueryResults> listOfQueryResultsList)
   {
@@ -115,35 +115,34 @@ public class Search
   }
 
   /**
-   * Liefert zur Anfrage queryString eine Liste von {@link Query}s, die der Reihe nach probiert
-   * werden sollten, gemäß der Suchstrategie searchStrategy (siehe
-   * {@link SearchStrategy#parse(ConfigThingy)}). Gibt es für die übergebene Anzahl Wörter keine
-   * Suchstrategie, so wird solange das letzte Wort entfernt bis entweder nichts mehr übrig ist oder
-   * eine Suchstrategie für die Anzahl Wörter gefunden wurde.
+   * Returns a list of {@link Query}s for the queryString that should be tried in sequence,
+   * according to the search strategy searchStrategy (see
+   * {@link SearchStrategy#parse(ConfigThingy)}). If there is no search strategy for the given number of words,
+   * words are removed from the end until either nothing is left or a search strategy for the number of words is found.
    *
-   * @return die leere Liste falls keine Liste bestimmt werden konnte.
+   * @return the empty list if no list could be determined.
    */
   private static List<Query> parseQuery(SearchStrategy searchStrategy, String queryString)
   {
     List<Query> queryList = new ArrayList<>();
 
-    // Kommata durch Space ersetzen (d.h. "Benkmann,Matthias" -> "Benkmann
-    // Matthias")
+    // Replace commas with space (i.e. "Benkmann,Matthias" -> "Benkmann Matthias")
+
     queryString = queryString.replaceAll(",", " ");
 
-    // Suchstring zerlegen.
+    // Split search string.
     Stream<String> queryStream = Arrays.stream(queryString.trim().split("\\p{Space}+"));
-    // Formatieren und leere Wörter entfernen
+    // Format and remove empty words
     String[] queryArray = queryStream.map(Search::formatQuery).filter(query -> query.length() != 0)
         .toArray(String[]::new);
 
     int count = queryArray.length;
 
-    // Passende Suchstrategie finden; falls nötig dazu Wörter am Ende weglassen.
+    // Find matching search strategy; if necessary, remove words from the end.
     while (count >= 0 && searchStrategy.getTemplate(count) == null)
       --count;
 
-    // keine Suchstrategie gefunden
+    // no search strategy found
     if (count < 0)
     {
       return queryList;
@@ -158,10 +157,9 @@ public class Search
     return queryList;
   }
 
-  /**
-   * Benutzerseitig wir nur ein einzelnes Sternchen am Ende eines Wortes akzeptiert. Deswegen
-   * entferne alle anderen Sternchen. Ein Punkt am Ende eines Wortes wird als Abkürzung
-   * interpretiert und durch Sternchen ersetzt.
+   /**
+   * Only a single asterisk at the end of a word is accepted by the user. Therefore, remove all other asterisks.
+   * A period at the end of a word is interpreted as an abbreviation and replaced by an asterisk.
    */
   private static String formatQuery(String query)
   {
@@ -180,9 +178,9 @@ public class Search
   }
 
   /**
-   * Nimmt ein Template für eine Suchanfrage entgegen (das Variablen der Form "${suchanfrageX}"
-   * enthalten kann) und instanziiert es mit Wörtern aus words, wobei nur die ersten wordcount
-   * Einträge von words beachtet werden.
+   * Takes a template for a search query (which may contain variables of the form "${suchanfrageX}")
+   * and instantiates it with words from words, considering only the first wordcount
+   * entries of words.
    */
   private static Query resolveTemplate(Query template, String[] words, int wordcount)
   {

--- a/core/src/main/java/org/libreoffice/lots/db/SearchStrategy.java
+++ b/core/src/main/java/org/libreoffice/lots/db/SearchStrategy.java
@@ -32,35 +32,32 @@ import java.util.regex.Pattern;
 import org.libreoffice.lots.config.ConfigThingy;
 
 /**
- * Eine Suchstrategie liefert für eine gegebene Wortzahl eine Liste von Templates für
- * Suchanfragen, die der Reihe nach mit den Wörtern probiert werden sollen bis ein
- * Ergebnis gefunden ist.
+ * A search strategy provides a list of templates for search queries for a given number of words,
+ * which should be tried in sequence with the words until a result is found.
  */
 public class SearchStrategy
 {
   /**
-   * Bildet eine Wortanzahl ab auf eine Liste von {@link Query}-Objekten, die
-   * passende Templates darstellen.
+   * Maps a word count to a list of {@link Query} objects that represent matching templates.
    */
   private Map<Integer, List<Query>> mapWordcountToListOfQuerys;
 
   /**
-   * {@link #mapWordcountToListOfQuerys} wird per Referenz eingebunden und
-   * entsprechende Ergebnisse aus dieser Map werden von {@link #getTemplate(int)}
-   * zurückgeliefert.
+   * {@link #mapWordcountToListOfQuerys} is included by reference and
+   * corresponding results from this map are returned by {@link #getTemplate(int)}.
    */
+  
   private SearchStrategy()
   {
     this.mapWordcountToListOfQuerys = new HashMap<>();
   }
 
   /**
-   * Parst den "SearchStrategy"-Abschnitt von conf und liefert eine entsprechende
+   * Parses the "SearchStrategy" section of conf and returns a corresponding
    * SearchStrategy.
    *
    * @param conf
-   *          das {@link ConfigThingy}, dessen "SearchStrategy"-Abschnitt geparst
-   *          werden soll.
+   *          the {@link ConfigThingy} whose "SearchStrategy" section should be parsed.
    */
   public static SearchStrategy parse(ConfigThingy conf)
   {
@@ -106,13 +103,11 @@ public class SearchStrategy
   }
 
   /**
-   * Liefert eine Liste von {@link Query}-Objekten, die jeweils ein Template für eine
-   * Query sind, die bei einer Suchanfrage mit wordcount Wörtern durchgeführt werden
-   * soll. Die Querys sollen in der Reihenfolge in der sie in der Liste stehen
-   * durchgeführt werden solange bis eine davon ein Ergebnis liefert.
+   * Returns a list of {@link Query} objects, each representing a template for a
+   * query that should be executed for a search request with wordcount words.
+   * The queries should be executed in the order they appear in the list until one of them returns a result.
    *
-   * @return <code>null</code> falls keine Strategie für den gegebenen wordcount
-   *         vorhanden ist.
+   * @return <code>null</code> if no strategy is available for the given wordcount.
    */
   public List<Query> getTemplate(int wordcount)
   {

--- a/core/src/main/java/org/libreoffice/lots/db/SimpleDataset.java
+++ b/core/src/main/java/org/libreoffice/lots/db/SimpleDataset.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import org.libreoffice.lots.util.L;
 
 /**
- * Eine simple Implementierung des Interfaces Dataset.
+ * A simple implementation of the Dataset interface.
  */
 public class SimpleDataset implements Dataset
 {
@@ -38,15 +38,15 @@ public class SimpleDataset implements Dataset
   private String key;
 
   /**
-   * Erzeugt ein SimpleDataset, das eine Kopie von ds ist. Das erzeugte SimpleDataset
-   * ist von schema und ds unabhängig und hält keine Verknüpfungen darauf.
+   * Creates a SimpleDataset that is a copy of ds. The created SimpleDataset
+   * is independent of schema and ds and does not hold any references to them.
    *
    * @param schema
-   *          enthält die Namen aller zu kopierenden Spalten
+   *          contains the names of all columns to be copied
    * @param ds
-   *          der zu kopierende Datensatz.
+   *          the dataset to be copied.
    * @throws ColumnNotFoundException
-   *           falls eine Spalte aus schema dem Datensatz ds nicht bekannt ist
+   *           if a column from schema is not known to the dataset ds
    */
   public SimpleDataset(Collection<String> schema, Dataset ds)
       throws ColumnNotFoundException
@@ -60,10 +60,10 @@ public class SimpleDataset implements Dataset
   }
 
   /**
-   * Erzeugt ein SimpleDataset, das den Schlüssel key hat und dessen Daten von der
-   * Map data geliefert werden. Das Schema wird implizit durch die Schlüssel
-   * bestimmt, die data kennt (d.h. wenn data.containsKey(column), dann ist column im
-   * Schema). ACHTUNG! Sowohl schema als auch data werden per Referenz eingebunden.
+   * Creates a SimpleDataset with the key key and whose data is provided by the
+   * Map data. The schema is implicitly determined by the keys
+   * known to data (i.e., if data.containsKey(column), then column is in
+   * the schema). WARNING! Both schema and data are included by reference.
    */
   public SimpleDataset(String key, Map<String, String> data)
   {

--- a/core/src/main/java/org/libreoffice/lots/db/ThingyDatasource.java
+++ b/core/src/main/java/org/libreoffice/lots/db/ThingyDatasource.java
@@ -47,17 +47,16 @@ public class ThingyDatasource extends RAMDatasource
 
   private static final Pattern SPALTENNAME = Pattern.compile("^[a-zA-Z_][a-zA-Z_0-9]*$");
 
+
   /**
-   * Erzeugt eine neue ThingyDatasource.
+   * Creates a new ThingyDatasource.
    *
    * @param nameToDatasource
-   *          enthält alle bis zum Zeitpunkt der Definition dieser
-   *          ThingyDatasource bereits vollständig instanziierten Datenquellen.
+   *          contains all data sources that have already been fully instantiated at the time of the definition of this ThingyDatasource.
    * @param sourceDesc
-   *          der "DataSource"-Knoten, der die Beschreibung dieser
-   *          ThingyDatasource enthält.
+   *          the "DataSource" node that contains the description of this ThingyDatasource.
    * @param context
-   *          der Kontext relativ zu dem URLs aufgelöst werden sollen.
+   *          the context relative to which URLs should be resolved.
    */
   public ThingyDatasource(Map<String, Datasource> nameToDatasource, ConfigThingy sourceDesc, URL context)
       throws IOException
@@ -152,7 +151,7 @@ public class ThingyDatasource extends RAMDatasource
     try
     {
       ConfigThingy keys = sourceDesc.get("Schluessel");
-      // Exception werfen, falls kein Schluessel angegeben
+      // Throw exception if no key is specified
       keys.getFirstChild();
       for (ConfigThingy key : keys)
       {
@@ -173,21 +172,19 @@ public class ThingyDatasource extends RAMDatasource
     return keyCols.toArray(new String[keyCols.size()]);
   }
 
-  /**
-   * Erzeugt ein neues MyDataset aus der Beschreibung dsDesc. Die Methode
-   * erkennt automatisch, ob die Beschreibung in der Form ("Spaltenwert1",
-   * "Spaltenwert2",...) oder der Form (Spalte1 "Wert1" Spalte2 "Wert2" ...)
-   * ist.
+    /**
+   * Creates a new MyDataset from the description dsDesc. 
+   * The method automatically detects whether the description is in the form ("ColumnValue1", "ColumnValue2",...) 
+   * or in the form (Column1 "Value1" Column2 "Value2" ...).
    *
    * @param schema
-   *          das Datenbankschema
+   *          the database schema
    * @param schemaOrdered
-   *          das Datenbankschema mit erhaltener Spaltenreihenfolge entsprechend
-   *          Schema-Sektion.
+   *          the database schema with preserved column order according to the Schema section.
    * @param keyCols
-   *          die Schlüsselspalten
+   *          the key columns
    * @throws ConfigurationErrorException
-   *           im Falle von Verstössen gegen diverse Regeln.
+   *           in case of violations of various rules.
    */
   private Dataset createDataset(ConfigThingy dsDesc, List<String> schema, String[] schemaOrdered,
       String[] keyCols)
@@ -212,11 +209,11 @@ public class ThingyDatasource extends RAMDatasource
   }
 
   /**
-   * Erzeugt ein neues MyDataset aus der Beschreibung dsDesc. dsDesc muss in der
-   * Form (Spalte1 "Spaltenwert1" Spalte2 "Spaltenwert2 ...) sein.
+   * Creates a new MyDataset from the description dsDesc. 
+   * dsDesc must be in the form (Column1 "ColumnValue1" Column2 "ColumnValue2 ...).
    *
    * @throws ConfigurationErrorException
-   *           bei verstössen gegen diverse Regeln
+   *           in case of violations of various rules
    */
   private Dataset createDatasetUnordered(ConfigThingy dsDesc, List<String> schema, String[] keyCols)
   { // TESTED
@@ -237,12 +234,13 @@ public class ThingyDatasource extends RAMDatasource
     return new MyDataset(schema, data, keyCols);
   }
 
+
   /**
-   * Erzeugt ein neues MyDataset aus der Beschreibung dsDesc. dsDesc muss in der
-   * Form ("Spaltenwert1" "Spaltenwert2 ...) sein.
+   * Creates a new MyDataset from the description dsDesc. 
+   * dsDesc must be in the form ("ColumnValue1" "ColumnValue2 ...).
    *
    * @throws ConfigurationErrorException
-   *           bei verstössen gegen diverse Regeln
+   *           in case of violations of various rules
    */
   private Dataset createDatasetOrdered(ConfigThingy dsDesc, List<String> schema,
       String[] schemaOrdered, String[] keyCols)
@@ -288,11 +286,10 @@ public class ThingyDatasource extends RAMDatasource
     }
 
     /**
-     * Setzt aus den Werten der Schlüsselspalten separiert durch KEY_SEPARATOR
-     * den Schlüssel zusammen.
+     * Assembles the key from the values of the key columns separated by KEY_SEPARATOR.
      *
      * @param keyCols
-     *          die Namen der Schlüsselspalten
+     *          the names of the key columns
      */
     private void initKey(String[] keyCols)
     { // TESTED

--- a/core/src/main/java/org/libreoffice/lots/db/UnionDatasource.java
+++ b/core/src/main/java/org/libreoffice/lots/db/UnionDatasource.java
@@ -38,7 +38,7 @@ import org.libreoffice.lots.config.ConfigurationErrorException;
 import org.libreoffice.lots.util.L;
 
 /**
- * Datasource, die die Vereinigung 2er Datasources darstellt
+ * Datasource that represents the union of two datasources
  */
 public class UnionDatasource extends Datasource
 {
@@ -55,17 +55,14 @@ public class UnionDatasource extends Datasource
   private String name;
 
   /**
-   * Erzeugt eine neue UnionDatasource.
+   * Creates a new UnionDatasource.
    *
    * @param nameToDatasource
-   *          enthält alle bis zum Zeitpunkt der Definition dieser UnionDatasource
-   *          bereits vollständig instanziierten Datenquellen.
+   *          contains all data sources that have already been fully instantiated at the time of the definition of this UnionDatasource.
    * @param sourceDesc
-   *          der "DataSource"-Knoten, der die Beschreibung dieser UnionDatasource
-   *          enthält.
+   *          the "DataSource" node that contains the description of this UnionDatasource.
    * @param context
-   *          der Kontext relativ zu dem URLs aufgelöst werden sollen (zur Zeit nicht
-   *          verwendet).
+   *          the context relative to which URLs should be resolved (currently not used).
    */
   public UnionDatasource(Map<String, Datasource> nameToDatasource,
       ConfigThingy sourceDesc, URL context)
@@ -88,12 +85,11 @@ public class UnionDatasource extends Datasource
           + "Referenced datasource \"{1}\" missing or defined incorrectly", name, source2Name));
 
     /*
-     * Anmerkung: Die folgende Bedingung ist "unnötig" streng, aber um sie
-     * aufzuweichen (z.B. Gesamtschema ist Vereinigung der Schemata) wäre es
-     * erforderlich, einen Dataset-Wrapper zu implementieren, der dafür sorgt, dass
-     * alle Datasets, die in QueryResults zurück- geliefert werden das selbe Schema
-     * haben. Solange dafür keine Notwendigkeit ersichtlich ist, spare ich mir diesen
-     * Aufwand.
+     * Note: The following condition is "unnecessarily" strict, 
+     * but to relax it (e.g., the overall schema is the union of the schemas) 
+     * it would be necessary to implement a dataset wrapper that ensures that 
+     * all datasets returned in query results have the same schema. 
+     * As long as there is no apparent need for this, I will save myself the effort.
      */
     List<String> schema1 = source1.getSchema();
     List<String> schema2 = source2.getSchema();


### PR DESCRIPTION
# Pull Request: Translation of German Comments to English

## Overview

This pull request (PR) addresses the issue of German comments found in various source files within the LibreOffice repository. The primary goal is to translate these comments into English to enhance code readability and maintainability for all contributors.

## Files Translated

The following files have been updated with translated comments:

- **`core/src/main/java/org/libreoffice/lots/db/SchemaDatasource.java`**
- **`core/src/main/java/org/libreoffice/lots/db/Search.java`**
- **`core/src/main/java/org/libreoffice/lots/db/SearchStrategy.java`**
- **`core/src/main/java/org/libreoffice/lots/db/SimpleDataset.java`**
- **`core/src/main/java/org/libreoffice/lots/db/ThingyDatasource.java`**
- **`core/src/main/java/org/libreoffice/lots/db/UnionDatasource.java`**

## Summary of Changes

- Translated German comments to English to improve understanding and accessibility for the international development team.
- Ensured that the meaning and context of the original comments were preserved during translation.

## Why This Change?

Translating comments to English is crucial for:
- Improving code readability for international developers.
- Ensuring consistency in documentation across the codebase.
- Facilitating easier code maintenance and onboarding of new contributors.

## Related Issues

- Resolves issue partially [#393 ]