### PR TITLE
Fix: Improve null safety and error handling in findElementWithCmdURL

### DIFF
--- a/core/src/main/java/org/libreoffice/lots/comp/WollMux.java
+++ b/core/src/main/java/org/libreoffice/lots/comp/WollMux.java
@@ -329,24 +329,39 @@ public class WollMux extends WeakBase implements XServiceInfo, XDispatchProvider
    *          The dispatch URL of the menu entry to search.
    * @return The index or -1 if no such entry exists.
    */
-  private static int findElementWithCmdURL(UnoList<PropertyValue[]> menu, String cmdUrl)
-  {
-    try
-    {
-      for (int i = 0; i < menu.size(); ++i)
-      {
-        UnoProps desc = new UnoProps(menu.get(i));
-        for (PropertyValue prop : desc.getProps())
-        {
-          if (UnoProperty.COMMAND_URL.equals(prop.Name) && cmdUrl.equals(prop.Value))
-            return i;
-        }
-      }
-    } catch (Exception e)
-    {
-      LOGGER.trace("", e);
+  private static int findElementWithCmdURL(UnoList<PropertyValue[]> menu, String cmdUrl) {
+    if (menu == null || cmdUrl == null) {
+        LOGGER.warn("findElementWithCmdURL called with null arguments: menu={}, cmdUrl={}", menu, cmdUrl);
+        return -1;
     }
+
+    try {
+        for (int i = 0; i < menu.size(); ++i) {
+            PropertyValue[] propsArray = menu.get(i);
+            if (propsArray == null) {
+                LOGGER.debug("Skipping null PropertyValue[] at index {}", i);
+                continue;
+            }
+
+            UnoProps desc = new UnoProps(propsArray);
+
+            for (PropertyValue prop : desc.getProps()) {
+                if (UnoProperty.COMMAND_URL.equals(prop.Name) &&
+                    Objects.equals(cmdUrl, prop.Value)) {
+                    return i;
+                }
+            }
+        }
+    } catch (RuntimeException e) {
+        // Catch only unchecked exceptions that might indicate data issues
+        LOGGER.error("Unexpected runtime error while searching for cmdUrl={} in menu", cmdUrl, e);
+        throw e; // rethrow to avoid hiding critical bugs
+    } catch (Exception e) {
+        // Catch and log checked exceptions (e.g. UNO bridge issues)
+        LOGGER.error("Error while searching for cmdUrl={} in menu", cmdUrl, e);
+    }
+
     return -1;
-  }
+}
 
 }


### PR DESCRIPTION
the findElementWithCmdURL method to prevent hidden crashes and make error diagnosis easier:

Added null checks for menu, cmdUrl, and PropertyValue[] entries.

Replaced string equality with Objects.equals() for null-safe comparisons.

Improved exception handling:

RuntimeExceptions are logged and rethrown (so critical issues aren’t silently swallowed).

Checked exceptions are logged with context at error level.

Logging improvements: meaningful messages for invalid inputs and unexpected conditions.

These changes ensure that potential null pointer errors won’t bring down LibreOffice silently, and any actual root causes are visible in logs instead of being hidden behind a generic trace statement.